### PR TITLE
README: use --locked for install + document rustc >= 1.88 prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,28 @@ One-shot wipe in a single transaction, so bounded by three ceilings:
 
 ### Prerequisites
 
-[`near-cli-rs`](https://github.com/near/near-cli-rs) must already be installed and on your `$PATH` — this is an extension to it, not a standalone tool. 
+- [`near-cli-rs`](https://github.com/near/near-cli-rs) must already be installed and on your `$PATH` — this is an extension to it, not a standalone tool.
+- A Rust toolchain **≥ 1.88** (the extension is developed against 1.92). `cargo install` builds with your *default* toolchain and ignores the repo's `rust-toolchain.toml`, so if your default is older, install a newer one and prefix the commands below with it — e.g. `rustup toolchain install 1.92`, then `cargo +1.92 install …`.
 
 ### Installing the extension
 
 Directly from this GitHub repo:
 
 ```
-cargo install --git https://github.com/near-examples/near-clear-state near-clear-state
+cargo install --locked --git https://github.com/near-examples/near-clear-state near-clear-state
 ```
 
 Or from a local checkout:
 
 ```
 git clone https://github.com/near-examples/near-clear-state
-cargo install --path near-clear-state/extension
+cargo install --locked --path near-clear-state/extension
 ```
+
+`--locked` installs the exact dependency versions pinned in the committed
+`Cargo.lock`. Without it `cargo install` re-resolves to the latest compatible
+crates, some of which raise their minimum supported Rust version over time and
+will then fail to build on an otherwise-fine toolchain.
 
 Both put a `near-clear-state` binary in `~/.cargo/bin/`. As long as that
 directory is on your `$PATH` (alongside the `near` binary itself),


### PR DESCRIPTION
## What

Fixes the documented install flow in the README's **Install** section:

- Add `--locked` to both `cargo install` commands (`--git` and `--path`).
- Add a prerequisite note: requires a Rust toolchain **≥ 1.88** (repo dev-pins 1.92), and explain that `cargo install` uses the *default* toolchain, not the repo's `rust-toolchain.toml`.

## Why

Testing the documented `cargo install --git … near-clear-state` surfaced two failures:

1. **MSRV drift without `--locked`.** `cargo install` ignores the committed `Cargo.lock` and re-resolves to the latest compatible crates. Several transitive deps have since raised their MSRV (`cargo-util` 0.2.29 → 1.94, `near-jsonrpc-client` 0.21.1 → 1.93, `near-socialdb-client` 0.15.1 → 1.93), so the build fails even on a recent toolchain. The committed lock pins 1.92-compatible versions (`cargo-util` 0.2.20, `near-jsonrpc-client` 0.21.0, `near-socialdb-client` 0.15.0); `--locked` uses them.
2. **Unstated toolchain floor.** A copy-paste install on a default toolchain < 1.88 fails with `requires rustc 1.88 or newer`, because `cargo install --git` doesn't honor the repo's `rust-toolchain.toml`.

Verified working: `cargo +1.92 install --locked --git … near-clear-state` completes.

## Scope / safety

README **Install** section only. The reproducible-wasm verify section is untouched: `git checkout 4a0bcb2…`, `scripts/verify-wasm.sh`'s `EXPECTED_COMMIT`, and the bundled wasm are unchanged. Confirmed `./scripts/verify-wasm.sh` still prints `wasm matches` on this branch (build-context commit `4a0bcb2` stays a reachable ancestor of `main`), so this commit does not affect verification regardless of merge strategy.

The equivalent fix for `near/docs` (`tools/clear-state.mdx`) is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)